### PR TITLE
BUG: Fix loss of connection states when moving a multi-connected port

### DIFF
--- a/src/NodeConnectionInteraction.cpp
+++ b/src/NodeConnectionInteraction.cpp
@@ -167,8 +167,9 @@ disconnect(PortType portToDisconnect) const
 
   NodeState &state = _node->nodeState();
 
-  // clear pointer to Connection in the NodeState
-  state.getEntries(portToDisconnect)[portIndex].clear();
+  // since multiple connections are allowed, disconnect the currently selected connection only.
+  // so that the other connection information is not lost.
+  state.eraseConnection(portToDisconnect, portIndex, _connection->id());
 
   // 4) Propagate invalid data to IN node
   _connection->propagateEmptyData();


### PR DESCRIPTION
When a port has multiple connections, only one connection is selected when attempting to move it. During this process, all remaining connections to be lost. As a result, when the component is moved, the other port connections do not follow the component.


https://github.com/user-attachments/assets/bb3af280-8d90-41b8-a815-557b1de14d0f

